### PR TITLE
Small spelling mistake fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Adding new components isn't just a matter of adding HTML and CSS because our Des
 
 So contributing involves providing an abstract template definition to [MetaTemplate](https://www.npmjs.com/package/@springload/metatemplate).
 
-First see if there is an existing component available from the [Gov.UK Design System](https://design-system.service.gov.uk/). If so, then identify the HTML and CSS from that component in `packages/govtnz-ds-upstream/src/upstream/govuk/ANY_VERSION/` and note down the filenames. If the filenames were "h1.html" and "h1.css" then the `patternId` would be "h1", so add that to `build-spec.json` (within `packages/govtnz-ds/src/build-types`).
+First see if there is an existing component available from the [GOV.UK Design System](https://design-system.service.gov.uk/). If so, then identify the HTML and CSS from that component in `packages/govtnz-ds-upstream/src/upstream/govuk/ANY_VERSION/` and note down the filenames. If the filenames were "h1.html" and "h1.css" then the `patternId` would be "h1", so add that to `build-spec.json` (within `packages/govtnz-ds/src/build-types`).
 
 If you were to run `yarn build:all` then it would include that component in the build at `packages/govtnz-ds/build`, however you may want to make parts of the component configurable using MetaHTML (see MetaTemplate docs) and these can be added at `normalize-govuk.ts`.
 
@@ -69,6 +69,6 @@ Then [raise a PR](https://help.github.com/en/articles/creating-a-pull-request) a
 
 #### Fixes to existing components
 
-If it's an HTML or CSS fix to a Gov.UK-derived component then you can contribute fixes to `normalize-govuk.ts` and [raise a PR](https://help.github.com/en/articles/creating-a-pull-request).
+If it's an HTML or CSS fix to a GOV.UK-derived component then you can contribute fixes to `normalize-govuk.ts` and [raise a PR](https://help.github.com/en/articles/creating-a-pull-request).
 
 If it's a framework-specific fix then please raise an issue on [MetaTemplate](https://github.com/springload/metatemplate/issues).


### PR DESCRIPTION
Small thing - GOV.UK should be all capitals 😃 