### PR TITLE
Refactor normalize-govuk to use local templates

### DIFF
--- a/packages/govtnz-ds/package.json
+++ b/packages/govtnz-ds/package.json
@@ -36,7 +36,7 @@
     "es6-promise-pool": "^2.5.0",
     "filesize": "^4.1.2",
     "format-duration": "^1.3.1",
-    "glob": "^7.1.3",
+    "glob": "^7.1.4",
     "glob-promise": "^3.4.0",
     "jest": "^24.8.0",
     "jsdom": "^14.0.0",

--- a/packages/govtnz-ds/src/normalize-govuk.ts
+++ b/packages/govtnz-ds/src/normalize-govuk.ts
@@ -32,12 +32,9 @@ const getLocalTemplateMetaPath = (source:string, version:string, id:string):stri
 };
 
 const getLocalTemplateMarkup = (metaPath:string, id:string):string => {
-  console.log(id);
   if (metaPath === '') {
     return '';
   }
-
-  console.log(metaPath);
 
   const metaJson = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
 
@@ -58,7 +55,7 @@ const getLocalTemplateMarkup = (metaPath:string, id:string):string => {
   }
 
   const template = applicableTemplates.find(tpl => tpl.id === id) || applicableTemplates[0];
-  console.log(template);
+
   return fs.readFileSync(metaPath.replace('meta.json', template.filename), 'utf8');
 };
 

--- a/packages/govtnz-ds/src/template-definitions/govuk/2.12.0/button/button.html
+++ b/packages/govtnz-ds/src/template-definitions/govuk/2.12.0/button/button.html
@@ -1,0 +1,8 @@
+<button
+    class="g-button {{ disabled!?: g-button--disabled }} {{ level: g-button--secondary as secondary | g-button--warning as warning }}"
+    type="submit"
+    aria-disabled="{{ disabled!?: true }}"
+    disabled="{{ disabled!?: true }}"
+>
+    <mt-variable key="children">Example text</mt-variable>
+</button>

--- a/packages/govtnz-ds/src/template-definitions/govuk/2.12.0/button/meta.json
+++ b/packages/govtnz-ds/src/template-definitions/govuk/2.12.0/button/meta.json
@@ -1,0 +1,32 @@
+{
+    "templates": [
+        {
+            "id": "button",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__disabled",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__secondary",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__warning",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__with-active-state",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__with-focus-state",
+            "filename": "button.html"
+        },
+        {
+            "id": "button__with-hover-state",
+            "filename": "button.html"
+        }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7064,7 +7064,7 @@ glob@^4.3.1:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==


### PR DESCRIPTION
Just looking for some early feedback at this stage...

Templates are placed in `src/template-definitions/<SOURCE>/<VERSION>/<ID>` directories. This maps pretty well to the structure defined in `build-spec.json`. When a component is upgraded to a new upstream version in `build-spec.json` the template directory should be moved accordingly.

Each template directory has a `meta.json` file and one or more MetaTemplate flavoured `html` files. The `meta.json` file maps pattern ids to template files.

I'm running into one issue when building templates, for example with `$ yarn build:release -s govuk@2.12.0 && yarn build:compile`

Additional button templates and docs are being generated for `ButtonDisabled`, `ButtonSecondary` and others. Any idea why that's happening?