### PR TITLE
Make code examples accessible.

### DIFF
--- a/packages/govtnz-ds-website/src/commons/Example.tsx
+++ b/packages/govtnz-ds-website/src/commons/Example.tsx
@@ -321,7 +321,7 @@ export default class Example extends Component<Props, State> {
               />
             </div>
             <Details className="example__details" onChange={this.clickFormat}>
-              <Summary className="example__summary">
+              <Summary id={summaryId} className="example__summary">
                 <h5 className="example__summary-button">
                   Code
                   <Icon

--- a/packages/govtnz-ds-website/src/commons/Example.tsx
+++ b/packages/govtnz-ds-website/src/commons/Example.tsx
@@ -52,6 +52,9 @@ export default class Example extends Component<Props, State> {
       id: `select_${Math.random()
         .toString(36)
         .replace(/[^0-9a-fA-F]/gi, '')}`,
+      templateChooserId: `template_${Math.random()
+        .toString(36)
+        .replace(/[^0-9a-fA-F]/gi, '')}`,
       formatId: formatId,
       code: highlightCode(rawCode, formatId),
       hasClickedExpand: false,
@@ -277,7 +280,7 @@ export default class Example extends Component<Props, State> {
               </p>
             )}
 
-            <pre className="language-code example__code">
+            <pre className="language-code example__code" tabIndex="0" role="group">
               <code dangerouslySetInnerHTML={{ __html: code }} />
             </pre>
           </React.Fragment>

--- a/packages/govtnz-ds-website/src/commons/Example.tsx
+++ b/packages/govtnz-ds-website/src/commons/Example.tsx
@@ -23,6 +23,7 @@ type Props = {
 type State = {
   formatId: string;
   id: string;
+  summaryId: string,
   templateChooserId: string,
   code: string;
   hasClickedExpand: boolean;
@@ -48,14 +49,14 @@ export default class Example extends Component<Props, State> {
 
     const formatId = DEFAULT_FORMAT_ID;
     const rawCode = props.code[formatId];
+    const randomId = Math.random()
+    .toString(36)
+    .replace(/[^0-9a-fA-F]/gi, '');
 
     this.state = {
-      id: `select_${Math.random()
-        .toString(36)
-        .replace(/[^0-9a-fA-F]/gi, '')}`,
-      templateChooserId: `template_${Math.random()
-        .toString(36)
-        .replace(/[^0-9a-fA-F]/gi, '')}`,
+      id: `select_${randomId}`,
+      summaryId: `summary_${randomId}`,
+      templateChooserId: `template_${randomId}`,
       formatId: formatId,
       code: highlightCode(rawCode, formatId),
       hasClickedExpand: false,
@@ -175,6 +176,7 @@ export default class Example extends Component<Props, State> {
     const { iframeProps, codeOnly, code: allCode } = this.props;
     const {
       id,
+      summaryId,
       templateChooserId,
       formatId,
       code,
@@ -286,7 +288,7 @@ export default class Example extends Component<Props, State> {
               className="language-code example__code"
               tabIndex={0}
               role="group"
-              aria-describedby={templateChooserId}
+              aria-labelledby={`${summaryId} ${templateChooserId}`}
             >
               <code dangerouslySetInnerHTML={{ __html: code }} />
             </pre>

--- a/packages/govtnz-ds-website/src/commons/Example.tsx
+++ b/packages/govtnz-ds-website/src/commons/Example.tsx
@@ -23,6 +23,7 @@ type Props = {
 type State = {
   formatId: string;
   id: string;
+  templateChooserId: string,
   code: string;
   hasClickedExpand: boolean;
   supportsJavaScript: boolean;
@@ -174,6 +175,7 @@ export default class Example extends Component<Props, State> {
     const { iframeProps, codeOnly, code: allCode } = this.props;
     const {
       id,
+      templateChooserId,
       formatId,
       code,
       supportsClipboard,
@@ -188,7 +190,7 @@ export default class Example extends Component<Props, State> {
         {supportsJavaScript && (
           <React.Fragment>
             <div className="example__format">
-              <h6 style={{ margin: '0 0 24px' }}>
+              <h6 id={templateChooserId} style={{ margin: '0 0 24px' }}>
                 <label className="example__label" htmlFor={id}>
                   Template format:{' '}
                 </label>
@@ -280,7 +282,12 @@ export default class Example extends Component<Props, State> {
               </p>
             )}
 
-            <pre className="language-code example__code" tabIndex="0" role="group">
+            <pre
+              className="language-code example__code"
+              tabIndex={0}
+              role="group"
+              aria-describedby={templateChooserId}
+            >
               <code dangerouslySetInnerHTML={{ __html: code }} />
             </pre>
           </React.Fragment>

--- a/packages/govtnz-ds-website/src/commons/styles/components-example.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/components-example.scss
@@ -51,6 +51,10 @@
   @include large {
     padding: $spacing-40 $spacing-32 $spacing-32 !important;
   }
+
+  &:focus {
+    outline: 3px solid $color-ds-default-focus;
+  }
 }
 
 .example__format {

--- a/packages/react-accessible-details/src/summary.tsx
+++ b/packages/react-accessible-details/src/summary.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Context } from "./index";
 
 type Props = {
+  id?: string,
   children: React.ReactNode;
   className?: string | undefined;
 };
@@ -11,12 +12,13 @@ const KEYS = {
   SPACE: 32
 };
 
-export default function Summary({ children, className }: Props) {
+export default function Summary({ id, children, className }: Props) {
   return (
     <Context.Consumer>
       {value => {
         return (
           <summary
+            id={id}
             role="button"
             aria-expanded={value.isOpen}
             tabIndex={0}


### PR DESCRIPTION
This supports [DS-224](https://govtnz.atlassian.net/jira/software/projects/DS/boards/87?selectedIssue=DS-224) and DS-273(https://govtnz.atlassian.net/jira/software/projects/DS/boards/87?selectedIssue=DS-273). 

Todo:
- [x] Wait for `react-accessible-details` to support `id`.