### PR TITLE
Skip Link focus fix and removed outline on element with `tabindex=-1`.

### DIFF
--- a/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
@@ -79,6 +79,10 @@ body {
   }
 }
 
+[tabindex="-1"] {
+  outline: none;
+}
+
 // Print CSS
 @page { 
     /* this affects the margin in the printer settings */ 

--- a/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
@@ -79,7 +79,7 @@ body {
   }
 }
 
-[tabindex="-1"] {
+[tabindex='-1'] {
   outline: none;
 }
 

--- a/packages/govtnz-ds-website/src/components/SkipLink.tsx
+++ b/packages/govtnz-ds-website/src/components/SkipLink.tsx
@@ -14,6 +14,8 @@ const SkipLink = ({ href }: SkipLinkProps): JSX.Element => {
     // so getAttribute() is more appropriate here.
     const href = e.target.getAttribute('href').replace(/#/g, '');
     const focusableElement = document.getElementById(href);
+    focusableElement.setAttribute('tabindex', '-1');
+    focusableElement.focus();
     const scrollOption: boolean | Object = hasOSReducedMotion
       ? {
           behavior: 'auto',
@@ -21,8 +23,6 @@ const SkipLink = ({ href }: SkipLinkProps): JSX.Element => {
       : {
           behavior: 'smooth',
         };
-    focusableElement.setAttribute('tabindex', '-1');
-    focusableElement.focus();
     focusableElement.scrollIntoView(scrollOption);
     e.target.blur();
   }, []);

--- a/packages/govtnz-ds-website/src/components/SkipLink.tsx
+++ b/packages/govtnz-ds-website/src/components/SkipLink.tsx
@@ -23,8 +23,13 @@ const SkipLink = ({ href }: SkipLinkProps): JSX.Element => {
       : {
           behavior: 'smooth',
         };
-    focusableElement.scrollIntoView(scrollOption);
-    e.target.blur();
+
+    try {
+      focusableElement.scrollIntoView(scrollOption);
+    } catch (error) {
+      // For all other browsers that don't support scrollIntoView options.
+      focusableElement.scrollIntoView();
+    }
   }, []);
 
   return (

--- a/packages/govtnz-ds-website/src/components/SkipLink.tsx
+++ b/packages/govtnz-ds-website/src/components/SkipLink.tsx
@@ -10,20 +10,20 @@ const SkipLink = ({ href }: SkipLinkProps): JSX.Element => {
     e.preventDefault();
     const reduceMotionQuery = '(prefers-reduced-motion: reduce)';
     const hasOSReducedMotion = window.matchMedia(reduceMotionQuery).matches;
+    // e.target.href includes the domain e.g. `http://localhost#main-content
+    // so getAttribute() is more appropriate here.
     const href = e.target.getAttribute('href').replace(/#/g, '');
     const focusableElement = document.getElementById(href);
-
-    if (hasOSReducedMotion) {
-      focusableElement.setAttribute('tabindex', '-1');
-      focusableElement.focus();
-    } else {
-      // e.target.href includes the domain e.g. `http://localhost#main-content
-      // so getAttribute() is more appropriate here.
-      focusableElement.scrollIntoView({
-        behavior: 'smooth',
-      });
-    }
-
+    const scrollOption: boolean | Object = hasOSReducedMotion
+      ? {
+          behavior: 'auto',
+        }
+      : {
+          behavior: 'smooth',
+        };
+    focusableElement.setAttribute('tabindex', '-1');
+    focusableElement.focus();
+    focusableElement.scrollIntoView(scrollOption);
     e.target.blur();
   }, []);
 


### PR DESCRIPTION
This makes sure that when clicking the Skip Link it will do the following:
- Focus on the element id specified on the `href` of the link.
- Scrolls into view and support for the browsers.