### PR TITLE
Fix/ds 371 contain examples no js

### DIFF
--- a/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
@@ -99,6 +99,36 @@ a {
   }
 }
 
+code[class*='language-'],
+pre[class*='language-'],
+pre[class*='language-'] code {
+  color: #494949;
+  background: none;
+  text-shadow: 0 1px white;
+  font-size: 1rem;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+pre {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+}
+
 code {
   // We need to override styling coming from the prism-js theme.
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,

--- a/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
@@ -100,6 +100,7 @@ a {
 }
 
 pre {
+  // We need this for when js is disabled.
   padding: 1em;
   margin: 0.5em 0;
   overflow: auto;

--- a/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
@@ -99,33 +99,9 @@ a {
   }
 }
 
-code[class*='language-'],
-pre[class*='language-'],
-pre[class*='language-'] code {
-  color: #494949;
-  background: none;
-  text-shadow: 0 1px white;
-  font-size: 1rem;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  line-height: 1.5;
-
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
-
 pre {
   padding: 1em;
-  // margin: 0.5em 0;
+  margin: 0.5em 0;
   overflow: auto;
 }
 

--- a/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-typography.scss
@@ -125,7 +125,7 @@ pre[class*='language-'] code {
 
 pre {
   padding: 1em;
-  margin: 0.5em 0;
+  // margin: 0.5em 0;
   overflow: auto;
 }
 


### PR DESCRIPTION
-**Code examples not contained in box when JS off:**  I had a look at the css with the js loading with and without. When the code examples are contained with js it uses `overflow: auto` and a few other things which is coming from the `prisim-theme.css` which is from the`prism.js` library ..  I added that into the `elements-typography.scss `  and will now be contained when js is disabled. 

-[DS-371](https://govtnz.atlassian.net/browse/DS-371)