### PR TITLE
[DS-365] Print footnote for external links

### DIFF
--- a/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
@@ -95,3 +95,25 @@ body {
   /* this affects the margin in the printer settings */
   margin: 15mm 15mm 15mm 15mm;
 }
+
+.external-links-print-wrapper,
+.external-link-print-superscript {
+  display: none;
+}
+
+@media print {
+  .external-links-print-wrapper {
+    display: block;
+  }
+  .external-link-print-superscript {
+    display: inline;
+  }
+
+  // 'external-links-print-wrapper' won't load without JS,
+  // so non-JS users can see links inline in print view instead:
+  body:not(.js) {
+    a[href^='http']::after {
+      content: ' (' attr(href) ')';
+    }
+  }
+}

--- a/packages/govtnz-ds-website/src/components/layout.tsx
+++ b/packages/govtnz-ds-website/src/components/layout.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { StaticQuery, graphql, PageRendererProps } from 'gatsby';
+import { generatePrintLinksList } from '../utils';
 import Container from '@govtnz/ds/build/react-ts/FlexContainer';
 import Row from '@govtnz/ds/build/react-ts/FlexRow';
 import Column from '@govtnz/ds/build/react-ts/FlexColumn';
@@ -22,8 +23,12 @@ const Layout = (props: Props) => {
 
   useEffect(() => {
     if (document.body.classList) {
-      document.documentElement.classList.add('theme-default');
+      document.documentElement.classList.add('theme-default', 'js');
     }
+
+    window.onbeforeprint = () => {
+      generatePrintLinksList();
+    };
   }, []);
 
   return (
@@ -37,7 +42,7 @@ const Layout = (props: Props) => {
           }
         }
       `}
-      render={data => (
+      render={(data) => (
         <>
           <SkipLink href="#main-heading" key={path} />
           <Header siteTitle={data.site.siteMetadata.title} />

--- a/packages/govtnz-ds-website/src/utils/index.ts
+++ b/packages/govtnz-ds-website/src/utils/index.ts
@@ -1,0 +1,45 @@
+export function generatePrintLinksList() {
+  const existingWrapper = document.querySelector(
+    '.external-links-print-wrapper'
+  );
+
+  // Exit early if the user has already printed and generated the links
+  if (existingWrapper) return;
+
+  const mainContent = document.querySelector('main');
+  if (!mainContent) return;
+
+  const links = mainContent.querySelectorAll('a');
+  if (!links.length) return;
+
+  const linksWrapper = document.createElement('div');
+  linksWrapper.setAttribute('class', 'external-links-print-wrapper');
+  mainContent.appendChild(linksWrapper);
+
+  const linksWrapperHeading = document.createElement('h2');
+  linksWrapperHeading.innerHTML = 'Links';
+  linksWrapper.appendChild(linksWrapperHeading);
+
+  let counter = 1;
+  const linksList = document.createElement('ol');
+
+  links.forEach((link) => {
+    // If link is external
+    if (link.host !== window.location.host) {
+      // Add an item numbers next to the source link
+      const itemNumber = document.createElement('sup');
+      itemNumber.setAttribute('class', 'external-link-print-superscript');
+      itemNumber.innerHTML = `${counter}`;
+      link.parentNode.insertBefore(itemNumber, link.nextSibling);
+
+      // Add the link to footer:
+      const item = document.createElement('li');
+      item.innerHTML = link.href;
+      linksList.appendChild(item);
+
+      counter++;
+    }
+  });
+
+  linksWrapper.appendChild(linksList);
+}

--- a/packages/govtnz-ds-website/src/utils/index.ts
+++ b/packages/govtnz-ds-website/src/utils/index.ts
@@ -9,11 +9,11 @@ export function generatePrintLinksList() {
   const mainContent = document.querySelector('main');
   if (!mainContent) return;
 
-  const links = mainContent.querySelectorAll('a');
+  const links = Array.from(mainContent.querySelectorAll('a'));
   if (!links.length) return;
 
   const linksWrapper = document.createElement('div');
-  linksWrapper.setAttribute('class', 'external-links-print-wrapper');
+  linksWrapper.className = 'external-links-print-wrapper';
   mainContent.appendChild(linksWrapper);
 
   const linksWrapperHeading = document.createElement('h2');
@@ -28,7 +28,7 @@ export function generatePrintLinksList() {
     if (link.host !== window.location.host) {
       // Add an item numbers next to the source link
       const itemNumber = document.createElement('sup');
-      itemNumber.setAttribute('class', 'external-link-print-superscript');
+      itemNumber.className = 'external-link-print-superscript';
       itemNumber.innerHTML = `${counter}`;
       link.parentNode.insertBefore(itemNumber, link.nextSibling);
 


### PR DESCRIPTION
https://govtnz.atlassian.net/browse/DS-365

Looks like this for JS-folk:
![Screen Shot 2020-07-30 at 1 41 24 PM](https://user-images.githubusercontent.com/1134713/88870882-9f590880-d26a-11ea-8d70-71a83eb55702.png)

Non-JS-folk will have the link href appended to the link in print view instead.