### PR TITLE
fix/DS-359-site-logo-mob-jumping

### DIFF
--- a/packages/govtnz-ds-website/src/components/navigation-small.scss
+++ b/packages/govtnz-ds-website/src/components/navigation-small.scss
@@ -82,6 +82,11 @@
   top: 9px;
   left: 1rem;
   z-index: 3;
+  @include font-smoothing;
+
+  @supports (-webkit-touch-callout: none) {
+    top: 13px;
+  }
 }
 
 .navigation-modal__content {


### PR DESCRIPTION
The logo at mobile jumps when clicking on the mobile pop out [DS-359]https://govtnz.atlassian.net/browse/DS-359l) .

After investigating,  this is because it has two different DOM structures between the closed and open version. One is inside the modal. The aligning/displaying the logo have difference but it is quite hard to tell where from. 

- One of the versions is missing ` font-smoothing`  which make them look different, this is a bug @holloway ? I added it to the modal/nav version. 

 - The solution i came to makes it better on devices. Although I'm not sure if it is the best solution. If you have any ideas @holloway  Keen to hear :).
 

