### PR TITLE
fix/DS-361-hide-logo: update header icon with aria-hidden

### DIFF
--- a/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
@@ -111,9 +111,9 @@ body {
 
   // 'external-links-print-wrapper' won't load without JS,
   // so non-JS users can see links inline in print view instead:
-  body:not(.js) {
-    a[href^='http']::after {
-      content: ' (' attr(href) ')';
-    }
-  }
+  // body:not(.js) {
+  //   a[href^='http']::after {
+  //     content: ' (' attr(href) ')';
+  //   }
+  // }
 }

--- a/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
+++ b/packages/govtnz-ds-website/src/commons/styles/elements-global.scss
@@ -111,9 +111,9 @@ body {
 
   // 'external-links-print-wrapper' won't load without JS,
   // so non-JS users can see links inline in print view instead:
-  // body:not(.js) {
-  //   a[href^='http']::after {
-  //     content: ' (' attr(href) ')';
-  //   }
-  // }
+  body:not(.js) {
+    a[href^='http']::after {
+      content: ' (' attr(href) ')';
+    }
+  }
 }

--- a/packages/govtnz-ds-website/src/components/Icon.tsx
+++ b/packages/govtnz-ds-website/src/components/Icon.tsx
@@ -7,9 +7,10 @@ type Props = {
   focusable: 'true' | 'false';
   id: string;
   title?: string;
+  ariaHidden?: boolean;
 };
 
-const Icon = ({ className, role, focusable, id, title }: Props) => {
+const Icon = ({ className, role, focusable, id, title, ariaHidden }: Props) => {
   const [titleId] = useState(
     `logo-${Math.random()
       .toString()
@@ -22,6 +23,7 @@ const Icon = ({ className, role, focusable, id, title }: Props) => {
       role={role}
       focusable={focusable}
       aria-labelledby={title ? titleId : undefined}
+      aria-hidden={ariaHidden}
     >
       {title && <title id={titleId}>{title}</title>}
       <use xlinkHref={`#${id}`} />

--- a/packages/govtnz-ds-website/src/components/LogoLockUp.tsx
+++ b/packages/govtnz-ds-website/src/components/LogoLockUp.tsx
@@ -31,7 +31,12 @@ const LogoLockUp = ({ tabIndex, ariaHidden }: Props) => {
         </svg>
       </div>
       <div className="header__logo header__logo--hide@medium header__logo--hide-print">
-        <Icon className="header__icon" role="img" id={iconNZGShortLogo.id} />
+        <Icon
+          className="header__icon"
+          ariaHidden={true}
+          role="img"
+          id={iconNZGShortLogo.id}
+        />
       </div>
       <div className="header__title">Design System</div>
     </a>

--- a/packages/govtnz-ds-website/src/components/LogoLockUp.tsx
+++ b/packages/govtnz-ds-website/src/components/LogoLockUp.tsx
@@ -33,7 +33,7 @@ const LogoLockUp = ({ tabIndex, ariaHidden }: Props) => {
       <div className="header__logo header__logo--hide@medium header__logo--hide-print">
         <Icon
           className="header__icon"
-          ariaHidden={true}
+          ariaHidden
           role="img"
           id={iconNZGShortLogo.id}
         />

--- a/packages/govtnz-ds-website/src/components/navigation-small.scss
+++ b/packages/govtnz-ds-website/src/components/navigation-small.scss
@@ -69,7 +69,6 @@
 }
 
 .navigation-modal__header {
-  position: absolute;
   margin-bottom: 0 !important;
   top: 0;
   left: 0;

--- a/packages/govtnz-ds-website/src/components/navigationSmall.tsx
+++ b/packages/govtnz-ds-website/src/components/navigationSmall.tsx
@@ -91,7 +91,7 @@ class NavigationSmall extends React.Component<Props, State> {
             </Container>
           </div>
           <div className="navigation-modal__heading">
-            <LogoLockUp tabIndex={-1} ariaHidden={true} />
+            <LogoLockUp tabIndex={-1} ariaHidden />
           </div>
           <div className="navigation-modal__content">
             <div className="navigation-modal__scroll">


### PR DESCRIPTION
- Fixing [DS-361](https://govtnz.atlassian.net/browse/DS-361)

It also had a comment about the menu top being cut off at the top, the 'Get started'. @holloway  I removed `position: absolute; ` from `navigation-modal__header ` and it fixed this. But I was wondering if there was a reason for it being there? It looks and works okay to me. 
