### PR TITLE
fix/DS-371-code-example-not-contained - made element focusable

### DIFF
--- a/packages/govtnz-ds-website/src/commons/Example.tsx
+++ b/packages/govtnz-ds-website/src/commons/Example.tsx
@@ -303,7 +303,7 @@ export default class Example extends Component<Props, State> {
           return (
             <noscript key={codeType}>
               <h3>{CodeToName[codeType] || codeType}</h3>
-              <pre>
+              <pre tabIndex={0}>
                 <code>{allCode[codeType]}</code>
               </pre>
             </noscript>


### PR DESCRIPTION
- Addressing the  focusable issue when code examples has  JS off that Calin mentions when no js [DS-371](https://govtnz.atlassian.net/browse/DS-371).

- Calin also mentions that the  summary isn't showing when js is disabled.  @holloway From what I can see the way it has been built it relys on  js to render the text. Is this an issue ? 

